### PR TITLE
Fix Build for eModbus Library

### DIFF
--- a/.github/workflows/pio.yaml
+++ b/.github/workflows/pio.yaml
@@ -30,3 +30,9 @@ jobs:
 
       - name: Build PlatformIO Project
         run: pio run
+      
+      - name: Attach artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: firmware_esp32
+          path: .pio/build/az-delivery-devkit-v4/firmware.bin

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,9 +14,9 @@ board = az-delivery-devkit-v4
 framework = arduino
 monitor_speed = 115200
 lib_deps = 
+	ESP32Async/AsyncTCP
+	ESP32Async/ESPAsyncWebServer
 	donnycraft1/PIDController@^0.0.1
-	FS
-	ESP Async WebServer
 	arkhipenko/TaskScheduler@^3.7.0
 	https://github.com/Sensirion/arduino-liquid-flow.git
 	https://github.com/tzapu/WiFiManager

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -6,11 +6,16 @@
 
 //All library includes
 #include <Arduino.h>
+#include <SPI.h>
+#include <WiFi.h>
+#include <Update.h>
+#include <WebServer.h>
+#include <DNSServer.h>
 #include <Wire.h>
-#include <ESP_FlexyStepper.h>
 
 //all file includes
 #include "BioreactorVaribiles.hpp"
+#include "ESP_FlexyStepper.h"
 #include "sensirion-lf.h"
 #include "sensirion-lf.cpp"
 #include "WebHosting.hpp"


### PR DESCRIPTION
Fix PlatformIO configuration to use the [`eModbus` library](https://github.com/eModbus/eModbus).